### PR TITLE
feat: retry the quarto rendering with purrr::insistently

### DIFF
--- a/R/compile_qmd_course.R
+++ b/R/compile_qmd_course.R
@@ -20,6 +20,7 @@
 #' use this option to correctly edit their path.
 #' @param render_pdf logical. If TRUE, render a pdf version of the html file
 #' @param render_pdf_fun function. Function to use to render the pdf. Default to pagedown::chrome_print. The function need to take a path to a html file as input.
+#' @param render_qmd_purrr_insistently_rate_backoff function. Function to use to retry rendering qmd files in case of failure. Should be a purrr::rate_backoff function.
 #'
 #' @importFrom tools file_ext
 #' @importFrom htmltools htmlTemplate renderDocument save_html HTML
@@ -93,7 +94,11 @@ compile_qmd_course <- function(
   debug = FALSE,
   fix_img_path = TRUE,
   render_pdf = FALSE,
-  render_pdf_fun = pagedown::chrome_print
+  render_pdf_fun = pagedown::chrome_print,
+  render_qmd_purrr_insistently_rate_backoff = purrr::rate_backoff(
+    pause_base = 0.1,
+    max_times = 5
+  )
 ) {
   # check inputs and future settings
   not_all_files_are_qmd <- any(
@@ -157,7 +162,8 @@ compile_qmd_course <- function(
         img_root_dir = img_root_dir,
         output_format = output_format,
         metadata = metadata_qmd,
-        quiet = !debug
+        quiet = !debug,
+        purrr_insistently_rate_backoff = render_qmd_purrr_insistently_rate_backoff
       )
     },
     # make random number generation reproducible

--- a/R/fetch_future_settings.R
+++ b/R/fetch_future_settings.R
@@ -10,8 +10,7 @@
 #' @noRd
 #' @examples
 #' fetch_future_settings(vec_qmd_path = qmd, quiet = FALSE)
-fetch_future_settings <- function(
-  quiet = TRUE) {
+fetch_future_settings <- function(quiet = TRUE) {
   # look for future settings  (e.g. parallel, sequential, default)
   future_setting <- attr(plan(), "call")
   future_setting <- ifelse(
@@ -20,7 +19,7 @@ fetch_future_settings <- function(
     no = deparse(future_setting)
   )
 
-  if (isFALSE(quiet) && !grepl("default", future_setting)) {
+  if (isFALSE(quiet) && !grepl("sequential", future_setting)) {
     cli_alert_info(paste(
       "{{future}} is using {future_setting},",
       "to modify this use {.code future::plan()}"

--- a/R/render_single_qmd.R
+++ b/R/render_single_qmd.R
@@ -56,10 +56,18 @@ render_single_qmd <- function(
     paste0(basename(chapter), "_img")
   )
 
+  quarto_render_insistently <- purrr::insistently(
+    quarto_render,
+    rates = purrr::rate_backoff(
+      pause_base = 0.1,
+      max_times = 5
+    )
+  )
+
   # try rendering qmd and warn user if successful / fail
   tryCatch(
     expr = {
-      quarto_render(
+      quarto_render_insistently(
         input = qmd,
         metadata = c(metadata, list(`extract-media` = img_dir)),
         output_format = output_format,

--- a/R/render_single_qmd.R
+++ b/R/render_single_qmd.R
@@ -5,6 +5,7 @@
 #' @param qmd character. Path to the qmd file to render
 #' @param img_root_dir character. Path to the main image folder to extract media to
 #' @param metadata list. List of metadata to be used for rendering single qmd file
+#' @param purrr_insistently_rate_backoff function. Function to use to retry rendering qmd files in case of failure. Should be a purrr::rate_backoff function.
 #'
 #' @inheritParams compile_qmd_course
 #'
@@ -46,7 +47,11 @@ render_single_qmd <- function(
   img_root_dir = "img",
   output_format = "revealjs",
   metadata = NULL,
-  quiet = TRUE
+  quiet = TRUE,
+  purrr_insistently_rate_backoff = purrr::rate_backoff(
+    pause_base = 0.1,
+    max_times = 5
+  )
 ) {
   # set image sub-folder name
   chapter <- dirname(qmd)
@@ -58,10 +63,7 @@ render_single_qmd <- function(
 
   quarto_render_insistently <- purrr::insistently(
     quarto_render,
-    rate = purrr::rate_backoff(
-      pause_base = 0.1,
-      max_times = 5
-    )
+    rate = purrr_insistently_rate_backoff
   )
 
   # try rendering qmd and warn user if successful / fail

--- a/R/render_single_qmd.R
+++ b/R/render_single_qmd.R
@@ -58,7 +58,7 @@ render_single_qmd <- function(
 
   quarto_render_insistently <- purrr::insistently(
     quarto_render,
-    rates = purrr::rate_backoff(
+    rate = purrr::rate_backoff(
       pause_base = 0.1,
       max_times = 5
     )

--- a/man/compile_qmd_course.Rd
+++ b/man/compile_qmd_course.Rd
@@ -19,7 +19,9 @@ compile_qmd_course(
   debug = FALSE,
   fix_img_path = TRUE,
   render_pdf = FALSE,
-  render_pdf_fun = pagedown::chrome_print
+  render_pdf_fun = pagedown::chrome_print,
+  render_qmd_purrr_insistently_rate_backoff = purrr::rate_backoff(pause_base = 0.1,
+    max_times = 5)
 )
 }
 \arguments{
@@ -55,6 +57,8 @@ use this option to correctly edit their path.}
 \item{render_pdf}{logical. If TRUE, render a pdf version of the html file}
 
 \item{render_pdf_fun}{function. Function to use to render the pdf. Default to pagedown::chrome_print. The function need to take a path to a html file as input.}
+
+\item{render_qmd_purrr_insistently_rate_backoff}{function. Function to use to retry rendering qmd files in case of failure. Should be a purrr::rate_backoff function.}
 }
 \value{
 character. The path to the resulting html file

--- a/man/render_single_qmd.Rd
+++ b/man/render_single_qmd.Rd
@@ -9,7 +9,8 @@ render_single_qmd(
   img_root_dir = "img",
   output_format = "revealjs",
   metadata = NULL,
-  quiet = TRUE
+  quiet = TRUE,
+  purrr_insistently_rate_backoff = purrr::rate_backoff(pause_base = 0.1, max_times = 5)
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ render_single_qmd(
 \item{metadata}{list. List of metadata to be used for rendering single qmd file}
 
 \item{quiet}{logical. Output info in user console}
+
+\item{purrr_insistently_rate_backoff}{function. Function to use to retry rendering qmd files in case of failure. Should be a purrr::rate_backoff function.}
 }
 \value{
 logical. TRUE if rendering succeeded, FALSE otherwise. Side effect : render qmd as html

--- a/tests/testthat/test-fetch_future_settings.R
+++ b/tests/testthat/test-fetch_future_settings.R
@@ -1,26 +1,21 @@
-test_that("future settings does not speak for default behaviour", {
-  # set to default
-  plan("default")
-
+test_that("fetch_future_settings quiet TRUE vs FALSE", {
+  oplan <- plan("default")
+  on.exit(plan(oplan), add = TRUE)
   expect_message(
     object = {
-      fetch_future_settings(quiet = FALSE)
+      fetch_future_settings(FALSE)
     },
     regexp = NA
   )
 })
 
-test_that("future settings does not speak for default behaviour", {
-  # set a multisession with one worker
-  plan(future::multisession, workers = 1)
-
+test_that("fetch_future_settings speak when future::multisession", {
+  oplan <- plan(future::multisession, workers = 1)
+  on.exit(plan(oplan), add = TRUE)
   expect_message(
     object = {
       fetch_future_settings(quiet = FALSE)
     },
     regexp = "\\{future\\} is using plan\\(future::multisession, workers = 1\\)"
   )
-
-  # reset to default
-  plan("default")
 })


### PR DESCRIPTION
The qmd are now rendered insistently, with a param to modify this behavior